### PR TITLE
Add excludeScope option to avoid serving index when URL matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ module.exports = function(defaults) {
       // Where the location of your index file is at, defaults to `index.html`
       location: 'app-shell.html',
 
+      // Bypass esw-index and don't serve cached index file for matching URLs
+      excludeScope: [/\/non-ember-app(\/.*)?$/, /\/another-app(\/.*)?$/],
+
       // changing this version number will bust the cache
       version: '1'
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,10 +18,12 @@ module.exports = class Config extends Plugin {
     let options = this.options;
     let version = options.version || '1';
     let location = options.location || 'index.html';
+    let excludeScope = options.excludeScope || [];
 
     let module = '';
     module += `export const VERSION = '${version}';\n`;
     module += `export const INDEX_HTML_PATH = '${location}';\n`;
+    module += `export const INDEX_EXCLUDE_SCOPE = [${excludeScope}];\n`;
 
     fs.writeFileSync(path.join(this.outputPath, 'config.js'), module);
   }

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -1,7 +1,10 @@
 import {
   INDEX_HTML_PATH,
-  VERSION
+  VERSION,
+  INDEX_EXCLUDE_SCOPE
 } from 'ember-service-worker-index/service-worker/config';
+
+import { urlMatchesAnyPattern } from 'ember-service-worker/service-worker/url-utils';
 import cleanupCaches from 'ember-service-worker/service-worker/cleanup-caches';
 
 const CACHE_KEY_PREFIX = 'esw-index';
@@ -27,9 +30,10 @@ self.addEventListener('fetch', (event) => {
   let request = event.request;
   let isGETRequest = request.method === 'GET';
   let isHTMLRequest = request.headers.get('accept').indexOf('text/html') !== -1;
-  let isLocal = new URL(request.url).origin === location.origin
+  let isLocal = new URL(request.url).origin === location.origin;
+  let scopeExcluded = urlMatchesAnyPattern(request.url, INDEX_EXCLUDE_SCOPE);
 
-  if (isGETRequest && isHTMLRequest && isLocal) {
+  if (isGETRequest && isHTMLRequest && isLocal && !scopeExcluded) {
     event.respondWith(
       caches.match(INDEX_HTML_URL, { cacheName: CACHE_NAME })
     );


### PR DESCRIPTION
Adding a new option to allow use with non Ember pages on same domain, when keeping ember service worker in root folder makes sense because website pages are mainly powered by ember.

My use case: website with a Ghost blog living outside of Ember app in /blog folder. Service worker was always serving Ember index file, preventing visitors to move to visit blog pages from home page.

## Changes proposed in this pull request

This PR allows to add `excludeScope: [/\/blog(\/.*)?$/]` in esw-index options. An array of regex patterns is expected.

Includes docs update, tested with Ember 2.13 in FastBoot environment.

Thanks @martndemus and @DockYard !
