### PR TITLE
Provide an option to include only some paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ module.exports = function(defaults) {
       // Bypass esw-index and don't serve cached index file for matching URLs
       excludeScope: [/\/non-ember-app(\/.*)?$/, /\/another-app(\/.*)?$/],
 
+      // Leave blank serve index file for all URLs, otherwise ONLY URLs which match
+      // this pattern will be served the cached index file so you will need to list
+      // every route in your app.
+      includeScope: [/\/dashboard(\/.*)?$/, /\/admin(\/.*)?$/],
+
       // changing this version number will bust the cache
       version: '1'
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,11 +19,13 @@ module.exports = class Config extends Plugin {
     let version = options.version || '1';
     let location = options.location || 'index.html';
     let excludeScope = options.excludeScope || [];
+    let includeScope = options.includeScope || [];
 
     let module = '';
     module += `export const VERSION = '${version}';\n`;
     module += `export const INDEX_HTML_PATH = '${location}';\n`;
     module += `export const INDEX_EXCLUDE_SCOPE = [${excludeScope}];\n`;
+    module += `export const INDEX_INCLUDE_SCOPE = [${includeScope}];\n`;
 
     fs.writeFileSync(path.join(this.outputPath, 'config.js'), module);
   }

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -1,7 +1,8 @@
 import {
   INDEX_HTML_PATH,
   VERSION,
-  INDEX_EXCLUDE_SCOPE
+  INDEX_EXCLUDE_SCOPE,
+  INDEX_INCLUDE_SCOPE
 } from 'ember-service-worker-index/service-worker/config';
 
 import { urlMatchesAnyPattern } from 'ember-service-worker/service-worker/url-utils';
@@ -32,8 +33,9 @@ self.addEventListener('fetch', (event) => {
   let isHTMLRequest = request.headers.get('accept').indexOf('text/html') !== -1;
   let isLocal = new URL(request.url).origin === location.origin;
   let scopeExcluded = urlMatchesAnyPattern(request.url, INDEX_EXCLUDE_SCOPE);
+  let scopeIncluded = !INDEX_INCLUDE_SCOPE.length || urlMatchesAnyPattern(request.url, INDEX_INCLUDE_SCOPE);
 
-  if (isGETRequest && isHTMLRequest && isLocal && !scopeExcluded) {
+  if (isGETRequest && isHTMLRequest && isLocal && scopeIncluded && !scopeExcluded) {
     event.respondWith(
       caches.match(INDEX_HTML_URL, { cacheName: CACHE_NAME })
     );


### PR DESCRIPTION
Closes #1

This is an alternative (but works with) excludeScope and allows
application to enumerate exactly what URLs respond with the index file.
This is a way to avoid accidentally returning index for routes outside
the scope of the application which are not possible the list in
excludeScope.

I attempted to find a way to get the routes from the app itself, but I didn't find anything obvious.