### PR TITLE
Returns the cached version only when network request fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ module.exports = function(defaults) {
       // every route in your app.
       includeScope: [/\/dashboard(\/.*)?$/, /\/admin(\/.*)?$/],
 
+      // Returns the cached version only when network request fails
+      fallback: false,
+
       // changing this version number will bust the cache
       version: '1'
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,12 +20,14 @@ module.exports = class Config extends Plugin {
     let location = options.location || 'index.html';
     let excludeScope = options.excludeScope || [];
     let includeScope = options.includeScope || [];
+    let fallback = options.fallback || false;
 
     let module = '';
     module += `export const VERSION = '${version}';\n`;
     module += `export const INDEX_HTML_PATH = '${location}';\n`;
     module += `export const INDEX_EXCLUDE_SCOPE = [${excludeScope}];\n`;
     module += `export const INDEX_INCLUDE_SCOPE = [${includeScope}];\n`;
+    module += `export const INDEX_FALLBACK = ${fallback};\n`;
 
     fs.writeFileSync(path.join(this.outputPath, 'config.js'), module);
   }

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -46,7 +46,7 @@ self.addEventListener('fetch', (event) => {
 
   if (isGETRequest && isHTMLRequest && isLocal && scopeIncluded && !scopeExcluded) {
     if (INDEX_FALLBACK) {
-      event.respondWimth(
+      event.respondWith(
         caches.open(CACHE_NAME).then(cache => {
           return this._fetchIndex()
             .catch(() => this._returnCachedIndex());


### PR DESCRIPTION
## Changes proposed in this pull request

I add a new option `fallback` to activate this feature.
It returns cached version only when network fails else it fetch the index.
