### PR TITLE
Fix how cached responses are served for Safari 11.1

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -39,8 +39,8 @@ self.addEventListener('fetch', (event) => {
   let isTests = url.pathname === '/tests' && ENVIRONMENT === 'development';
 
   if (!isTests && isGETRequest && isHTMLRequest && isLocal && scopeIncluded && !scopeExcluded) {
-    event.respondWith(
-      caches.match(INDEX_HTML_URL, { cacheName: CACHE_NAME })
-    );
+    event.respondWith(async () => {
+      return await caches.match(INDEX_HTML_URL, { cacheName: CACHE_NAME });
+    }());
   }
 });


### PR DESCRIPTION
See https://github.com/DockYard/ember-service-worker/issues/117

I tested this on a local clone of dockyard.com and a brand new `ember-cli` project. It only seems to be a problem with `index.html`, not other assets.