### PR TITLE
Revert async/await in fetch event

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -39,8 +39,8 @@ self.addEventListener('fetch', (event) => {
   let isTests = url.pathname === '/tests' && ENVIRONMENT === 'development';
 
   if (!isTests && isGETRequest && isHTMLRequest && isLocal && scopeIncluded && !scopeExcluded) {
-    event.respondWith(async () => {
-      return await caches.match(INDEX_HTML_URL, { cacheName: CACHE_NAME });
-    }());
+    event.respondWith(
+      caches.match(INDEX_HTML_URL, { cacheName: CACHE_NAME })
+    );
   }
 });


### PR DESCRIPTION
This PR reverts the change introduced in #13, because the `async/await` actually causes a `Uncaught ReferenceError: regeneratorRuntime is not defined` when the service worker is reloaded (in Chrome). Unfortunately, replacing it with a regular Promise doesn't solve the Safari 11.1 issue, so that remains broken for now.