### PR TITLE
Add fallback for invalid cache response

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -46,6 +46,9 @@ self.addEventListener('fetch', (event) => {
             return response;
           }
 
+          // Re-fetch the resource in the event that the cache had been cleared
+          // (mostly an issue with Safari 11.1 where clearing the cache causes
+          // the browser to throw a non-descriptive blank error page).
           return fetch(INDEX_HTML_URL, { credentials: 'include' })
             .then((fetchedResponse) => {
               caches.open(CACHE_NAME).then((cache) => cache.put(INDEX_HTML_URL, fetchedResponse));

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -41,6 +41,17 @@ self.addEventListener('fetch', (event) => {
   if (!isTests && isGETRequest && isHTMLRequest && isLocal && scopeIncluded && !scopeExcluded) {
     event.respondWith(
       caches.match(INDEX_HTML_URL, { cacheName: CACHE_NAME })
+        .then((response) => {
+          if (response) {
+            return response;
+          }
+
+          return fetch(INDEX_HTML_URL, { credentials: 'include' })
+            .then((fetchedResponse) => {
+              caches.open(CACHE_NAME).then((cache) => cache.put(INDEX_HTML_URL, fetchedResponse));
+              return fetchedResponse.clone();
+            });
+        })
     );
   }
 });


### PR DESCRIPTION
This PR introduces a re-fetch fallback step in the event that the cached `INDEX_HTML_URL` response was invalidated.

See https://github.com/DockYard/ember-service-worker/issues/117