### PR TITLE
Update dependencies, require node 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-service-worker-index",
-  "version": "0.6.7",
+  "version": "0.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,39 +9,28 @@
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "blank-object": {
-      "version": "1.0.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/blank-object/-/blank-object-1.0.2.tgz",
-      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk="
-    },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "broccoli-merge-trees": {
-      "version": "1.2.4",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-      "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.1.tgz",
+      "integrity": "sha512-EFPBLbCoyCLdjJx0lxn+acWXK/GAZesXokS4OsF7HuB+WdnV76HVJPdfwp9TaXaUkrtb7eU+ymh9tY9wOGQjMQ==",
       "requires": {
         "broccoli-plugin": "^1.3.0",
-        "can-symlink": "^1.0.0",
-        "fast-ordered-set": "^1.0.2",
-        "fs-tree-diff": "^0.5.4",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0"
+        "merge-trees": "^2.0.0"
       }
     },
     "broccoli-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
-      "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
       "requires": {
         "promise-map-series": "^0.2.1",
         "quick-temp": "^0.1.3",
@@ -57,6 +46,11 @@
         "tmp": "0.0.28"
       }
     },
+    "clean-up-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
+      "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/concat-map/-/concat-map-0.0.1.tgz",
@@ -64,29 +58,22 @@
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
     },
-    "fast-ordered-set": {
-      "version": "1.0.3",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
-      "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
+    "fs-updater": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fs-updater/-/fs-updater-1.0.4.tgz",
+      "integrity": "sha512-0pJX4mJF/qLsNEwTct8CdnnRdagfb+LmjRPJ8sO+nCnAZLW0cTmz4rTgU25n+RvTuWSITiLKrGVJceJPBIPlKg==",
       "requires": {
-        "blank-object": "^1.0.1"
-      }
-    },
-    "fs-tree-diff": {
-      "version": "0.5.7",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-      "integrity": "sha1-MV4rCY1f5/YiiArJZbGwUYaKyHE=",
-      "requires": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
+        "can-symlink": "^1.0.0",
+        "clean-up-path": "^1.0.0",
+        "heimdalljs": "^0.2.5",
+        "heimdalljs-logger": "^0.1.9",
+        "rimraf": "^2.6.2"
       }
     },
     "fs.realpath": {
@@ -95,9 +82,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -108,9 +95,9 @@
       }
     },
     "heimdalljs": {
-      "version": "0.2.5",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/heimdalljs/-/heimdalljs-0.2.5.tgz",
-      "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+      "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
       "requires": {
         "rsvp": "~3.2.1"
       },
@@ -123,12 +110,12 @@
       }
     },
     "heimdalljs-logger": {
-      "version": "0.1.9",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
-      "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz",
+      "integrity": "sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==",
       "requires": {
         "debug": "^2.2.0",
-        "heimdalljs": "^0.2.0"
+        "heimdalljs": "^0.2.6"
       }
     },
     "inflight": {
@@ -145,10 +132,19 @@
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "merge-trees": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
+      "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+      "requires": {
+        "fs-updater": "^1.0.4",
+        "heimdalljs": "^0.2.5"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -162,11 +158,6 @@
       "version": "2.0.0",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "once": {
       "version": "1.4.0",
@@ -185,11 +176,6 @@
       "version": "1.0.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-posix": {
-      "version": "1.0.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
     },
     "promise-map-series": {
       "version": "0.2.3",
@@ -211,16 +197,16 @@
     },
     "rimraf": {
       "version": "2.6.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "^7.0.5"
       }
     },
     "rsvp": {
       "version": "3.6.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha1-LpZJFZmpbN4bUV1WdKj3qRRSkmo="
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "sprintf-js": {
       "version": "1.1.1",
@@ -229,8 +215,8 @@
     },
     "symlink-or-copy": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
-      "integrity": "sha1-XUkQjiq4JKNAabaJdEhsKQAgs5M="
+      "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
+      "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg=="
     },
     "tmp": {
       "version": "0.0.28",
@@ -241,9 +227,9 @@
       }
     },
     "underscore.string": {
-      "version": "3.3.4",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/underscore.string/-/underscore.string-3.3.4.tgz",
-      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
       "requires": {
         "sprintf-js": "^1.0.3",
         "util-deprecate": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/DockYard/ember-service-worker-index",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "author": "",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "ember-service-worker-plugin"
   ],
   "dependencies": {
-    "broccoli-merge-trees": "^1.2.1",
-    "broccoli-plugin": "^1.3.0"
+    "broccoli-merge-trees": "^3.0.1",
+    "broccoli-plugin": "^1.3.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Updates dependencies and moves to requiring node 6 (4 is no longer supported).