### PR TITLE
Added the ability to fetch from server first and fallback to cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ module.exports = function(defaults) {
       // every route in your app.
       includeScope: [/\/dashboard(\/.*)?$/, /\/admin(\/.*)?$/],
 
+      // Indicate the caching strategy to use for the index.html file.
+      // cache-first: read from the cache first
+      // fallback: attempt to load but fallback to the cache after the timeout specified in "timeout" option
+      // defaults to "cache-first"
+      strategy: 'fallback',
+
+      // Used along with strategy of "fallback".
+      // The number of milliseconds to wait for newly loaded index file before falling back to the cache
+      // defaults to 500 milliseconds
+      timeout: 500,
+
       // Changing this version number will bust the cache, but you probably do not
       // want to be doing this manually, but rather using `versionStrategy` as
       // explained here http://ember-service-worker.com/documentation/configuration/#versioning

--- a/lib/config.js
+++ b/lib/config.js
@@ -27,6 +27,8 @@ module.exports = class Config extends Plugin {
     let location = options.location || "index.html";
     let excludeScope = options.excludeScope || [];
     let includeScope = options.includeScope || [];
+    let strategy = options.strategy || 'cache-first';
+    let timeout = options.timeout || 500;
 
     let fileLocation = location;
     if (fileLocation[fileLocation.length - 1] === "/") {
@@ -43,6 +45,8 @@ module.exports = class Config extends Plugin {
     module += `export const INDEX_EXCLUDE_SCOPE = [${excludeScope}];\n`;
     module += `export const INDEX_INCLUDE_SCOPE = [${includeScope}];\n`;
     module += `self.INDEX_FILE_HASH = '${hash}';\n`;
+    module += `export const STRATEGY = '${strategy}';\n`;
+    module += `export const TIMEOUT = '${timeout}';\n`;
 
     fs.writeFileSync(path.join(this.outputPath, "config.js"), module);
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,7 +28,8 @@ module.exports = class Config extends Plugin {
     let excludeScope = options.excludeScope || [];
     let includeScope = options.includeScope || [];
     let strategy = options.strategy || 'cache-first';
-    let timeout = options.timeout || 500;
+    let configuredTimeout = parseInt(`${options.timeout}`, 10);
+    let timeout = isNaN(configuredTimeout) || configuredTimeout <= 0 ? 500 : configuredTimeout; // 0 would be the same as cache-first strategy
 
     let fileLocation = location;
     if (fileLocation[fileLocation.length - 1] === "/") {

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -74,7 +74,7 @@ function cacheFirstFetch(event) {
 function cacheFallbackFetch(event, fetchTimeout) {
   const FETCH_TIMEOUT = fetchTimeout;
   let didTimeOut = false;
-  new Promise(function(resolve, reject) {
+  new Promise(function(_resolve, reject) {
     const timeout = setTimeout(function() {
       didTimeOut = true;
       reject(new Error('Request timed out'));


### PR DESCRIPTION
This PR introduces the feature of fetching `index.html` from the server rather than immediately fetching from the cache. To enable this feature, the user must provide two options: `strategy` & `timeout`. For the add-on to behave normally, the user will pass `strategy: cache-first` or avoid passing the option and to enable cache fallback they will pass `strategy: fallback`. The other optional option is a timeout duration. It will default to `500` milliseconds but can be overwritten.

This functionality allows for grabbing the latest `index.html` upon page load rather than serving up the cache and determining shortly after that there is a newer version. 